### PR TITLE
Modularização de uma pasta settings para o https

### DIFF
--- a/pbjr/settings/development.py
+++ b/pbjr/settings/development.py
@@ -1,1 +1,0 @@
-DEBUG = True

--- a/pbjr/settings/development.py
+++ b/pbjr/settings/development.py
@@ -1,0 +1,1 @@
+DEBUG = True

--- a/pbjr/settings/production.py
+++ b/pbjr/settings/production.py
@@ -2,6 +2,11 @@ from .base import *
 
 DEBUG = False
 
+
+SECURE_SSL_REDIRECT = True
+
+SECURE_PROXY_SSL_HEADER = (‘HTTP_X_FORWARDED_PROTO’, ‘https’)
+
 # django-storages dropbox
 DEFAULT_FILE_STORAGE = 'storages.backends.dropbox.DropBoxStorage'
 DROPBOX_OAUTH2_TOKEN = 'P-DMhRXchXAAAAAAAAAAC8O1yV4Ta9-DDyyoxfuXMpw-xwHFrMtVzqvipdQkQjML'

--- a/pbjr/wsgi.py
+++ b/pbjr/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pbjr.settings.production")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pbjr.settings.development")
 
 application = get_wsgi_application()

--- a/pbjr/wsgi.py
+++ b/pbjr/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pbjr.settings.development")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pbjr.settings.production")
 
 application = get_wsgi_application()


### PR DESCRIPTION
Adicionado arquivo developmente.py + init.py na pasta settings;

Adicionado linha de comando SECURE_SSL_REDIRECT = True SECURE_PROXY_SSL_HEADER = (‘HTTP_X_FORWARDED_PROTO’, ‘https’) no production.py

Modificado wsgi.py